### PR TITLE
feat(indexer): Atlas ingestion feature flag and minimal pipeline skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tokio-retry = "0.3"
 http-body-util = "0.1"
 clap = { version = "4.5.45", features = ["derive"] }
 
+
 [lib]
 name = "arch_indexer"
 path = "src/lib.rs"
@@ -67,3 +68,6 @@ path = "src/bin/test_realtime_indexing.rs"
 tokio = { version = "1.0", features = ["full"] }
 tower = { version = "0.4", features = ["util"] }
 hyper = { version = "0.14", features = ["full"] }
+
+[features]
+default = []

--- a/arch-indexer-microservices/indexer/Cargo.toml
+++ b/arch-indexer-microservices/indexer/Cargo.toml
@@ -34,10 +34,8 @@ tokio-retry = "0.3"
 http-body-util = "0.1"
 clap = { version = "4.5.45", features = ["derive"] }
 
-# Optional dependencies for Atlas ingestion mode (local path)
 async-trait = { version = "0.1", optional = true }
 tokio-util = { version = "0.7", optional = true }
-atlas-core = { path = "/Users/brianhoffman/Projects/temporary/atlas/core", optional = true }
 
 [lib]
 name = "indexer"
@@ -53,5 +51,12 @@ default = []
 atlas_ingestion = [
     "dep:async-trait",
     "dep:tokio-util",
-    "dep:atlas-core",
 ]
+
+# Pull atlas-core only when the feature is enabled to avoid git fetch in default builds
+## Note: atlas-core git dependency will be added once the Arch-Network/atlas fork is created.
+## Example configuration to add later:
+## [dependencies]
+## atlas-core = { git = "https://github.com/Arch-Network/atlas", package = "atlas-core", rev = "<commit>", optional = true }
+## [features]
+## atlas_ingestion = ["dep:async-trait", "dep:tokio-util", "dep:atlas-core"]

--- a/arch-indexer-microservices/indexer/Cargo.toml
+++ b/arch-indexer-microservices/indexer/Cargo.toml
@@ -36,6 +36,7 @@ clap = { version = "4.5.45", features = ["derive"] }
 
 async-trait = { version = "0.1", optional = true }
 tokio-util = { version = "0.7", optional = true }
+atlas-core = { git = "https://github.com/Arch-Network/atlas", package = "atlas-core", branch = "master", optional = true }
 
 [lib]
 name = "indexer"
@@ -51,12 +52,8 @@ default = []
 atlas_ingestion = [
     "dep:async-trait",
     "dep:tokio-util",
+    "dep:atlas-core",
 ]
 
 # Pull atlas-core only when the feature is enabled to avoid git fetch in default builds
-## Note: atlas-core git dependency will be added once the Arch-Network/atlas fork is created.
-## Example configuration to add later:
-## [dependencies]
-## atlas-core = { git = "https://github.com/Arch-Network/atlas", package = "atlas-core", rev = "<commit>", optional = true }
-## [features]
-## atlas_ingestion = ["dep:async-trait", "dep:tokio-util", "dep:atlas-core"]
+## TODO: Pin to a specific commit (rev = "<sha>") for reproducible builds.

--- a/arch-indexer-microservices/indexer/Cargo.toml
+++ b/arch-indexer-microservices/indexer/Cargo.toml
@@ -34,6 +34,11 @@ tokio-retry = "0.3"
 http-body-util = "0.1"
 clap = { version = "4.5.45", features = ["derive"] }
 
+# Optional dependencies for Atlas ingestion mode (local path)
+async-trait = { version = "0.1", optional = true }
+tokio-util = { version = "0.7", optional = true }
+atlas-core = { path = "/Users/brianhoffman/Projects/temporary/atlas/core", optional = true }
+
 [lib]
 name = "indexer"
 path = "src/lib.rs"
@@ -41,3 +46,12 @@ path = "src/lib.rs"
 [[bin]]
 name = "indexer"
 path = "src/main.rs"
+
+[features]
+default = []
+# Enable Atlas-based ingestion path. Keeps deps optional unless this feature is selected.
+atlas_ingestion = [
+    "dep:async-trait",
+    "dep:tokio-util",
+    "dep:atlas-core",
+]

--- a/arch-indexer-microservices/indexer/src/lib.rs
+++ b/arch-indexer-microservices/indexer/src/lib.rs
@@ -7,3 +7,6 @@ pub mod utils;
 pub use config::Settings;
 pub use indexer::HybridSync;
 pub use db::models::{Block, Transaction};
+
+#[cfg(feature = "atlas_ingestion")]
+pub mod pipeline_atlas;

--- a/arch-indexer-microservices/indexer/src/pipeline_atlas.rs
+++ b/arch-indexer-microservices/indexer/src/pipeline_atlas.rs
@@ -1,0 +1,55 @@
+#![cfg(feature = "atlas_ingestion")]
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+
+use atlas_core as core;
+use core::datasource::{Datasource, DatasourceId, UpdateType, Updates};
+use core::metrics::{Metrics, MetricsCollection};
+use core::pipeline::{Pipeline, ShutdownStrategy};
+
+struct NoopMetrics;
+
+#[async_trait]
+impl Metrics for NoopMetrics {
+    async fn initialize(&self) -> core::error::IndexerResult<()> { Ok(()) }
+    async fn flush(&self) -> core::error::IndexerResult<()> { Ok(()) }
+    async fn shutdown(&self) -> core::error::IndexerResult<()> { Ok(()) }
+    async fn update_gauge(&self, _key: &str, _value: f64) -> core::error::IndexerResult<()> { Ok(()) }
+    async fn increment_counter(&self, _key: &str, _n: u64) -> core::error::IndexerResult<()> { Ok(()) }
+    async fn record_histogram(&self, _key: &str, _value: f64) -> core::error::IndexerResult<()> { Ok(()) }
+}
+
+struct NoopDatasource;
+
+#[async_trait]
+impl Datasource for NoopDatasource {
+    async fn consume(
+        &self,
+        _id: DatasourceId,
+        _sender: tokio::sync::mpsc::Sender<(Updates, DatasourceId)>,
+        cancellation: CancellationToken,
+        _metrics: Arc<MetricsCollection>,
+    ) -> core::error::IndexerResult<()> {
+        let _ = cancellation.cancelled().await;
+        Ok(())
+    }
+
+    fn update_types(&self) -> Vec<UpdateType> { vec![] }
+}
+
+pub async fn run_minimal_pipeline() -> Result<()> {
+    let mut pipeline: Pipeline = Pipeline::builder()
+        .datasource(NoopDatasource)
+        .metrics(Arc::new(NoopMetrics))
+        .shutdown_strategy(ShutdownStrategy::Immediate)
+        .build()?;
+
+    pipeline.run().await?;
+    Ok(())
+}
+
+


### PR DESCRIPTION
Closes #2 - Add atlas_ingestion feature and minimal Atlas pipeline in microservices indexer; depend on Arch-Network/atlas fork; default builds unaffected