### PR TITLE
feat(indexer): Atlas transaction bridge processor (DB writes)

### DIFF
--- a/arch-indexer-microservices/indexer/Cargo.toml
+++ b/arch-indexer-microservices/indexer/Cargo.toml
@@ -39,6 +39,8 @@ tokio-util = { version = "0.7", optional = true }
 atlas-core = { git = "https://github.com/Arch-Network/atlas", package = "atlas-core", branch = "master", optional = true }
 atlas-arch-rpc-datasource = { git = "https://github.com/Arch-Network/atlas", package = "atlas-arch-rpc-datasource", branch = "master", optional = true }
 atlas-rocksdb-checkpoint-store = { git = "https://github.com/Arch-Network/atlas", package = "atlas-rocksdb-checkpoint-store", branch = "master", optional = true }
+arch_program = { version = "0.5.8", optional = true }
+arch_program_atlas = { git = "https://github.com/Arch-Network/atlas", package = "arch_program", branch = "master", optional = true }
 
 [lib]
 name = "indexer"
@@ -57,6 +59,7 @@ atlas_ingestion = [
     "dep:atlas-core",
     "dep:atlas-arch-rpc-datasource",
     "dep:atlas-rocksdb-checkpoint-store",
+    "dep:arch_program_atlas",
 ]
 
 # Pull atlas-core only when the feature is enabled to avoid git fetch in default builds

--- a/arch-indexer-microservices/indexer/src/main.rs
+++ b/arch-indexer-microservices/indexer/src/main.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
         let ws_url = &settings.arch_node.websocket_url;
         let rocks_path = std::env::var("ATLAS_CHECKPOINT_PATH").unwrap_or_else(|_| "./.atlas_checkpoints".to_string());
         info!("🧪 Atlas ingestion mode enabled; starting syncing pipeline (rpc={}, ws={})", rpc_url, ws_url);
-        if let Err(e) = pipeline_atlas::run_syncing_pipeline(rpc_url, ws_url, &rocks_path).await {
+        if let Err(e) = pipeline_atlas::run_syncing_pipeline(rpc_url, ws_url, &rocks_path, std::sync::Arc::new(pool)).await {
             error!("Atlas syncing pipeline failed: {}", e);
             std::process::exit(1);
         }


### PR DESCRIPTION
Closes #4. Adds a feature-gated transaction processor that upserts transactions (hash, block_height, status) using PgPool; registers as Transaction pipe in Atlas pipeline; uses fork-sourced arch_program under atlas feature to avoid type mismatches while the rest of the app can use crates.io 0.5.8.