### PR TITLE
Atlas: Accounts + AccountDeletions processors, accounts table (closes #6)

### DIFF
--- a/migrations/20250908_add_accounts_table.sql
+++ b/migrations/20250908_add_accounts_table.sql
@@ -1,0 +1,13 @@
+-- Idempotent creation of accounts table for Atlas account processors (Issue #6)
+CREATE TABLE IF NOT EXISTS accounts (
+    pubkey TEXT PRIMARY KEY,
+    lamports BIGINT NOT NULL,
+    owner TEXT NOT NULL,
+    data BYTEA NOT NULL,
+    height BIGINT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_accounts_owner ON accounts(owner);
+CREATE INDEX IF NOT EXISTS idx_accounts_height ON accounts(height);
+


### PR DESCRIPTION
Implements accounts table migration and runtime schema; adds RawAccountDecoder, AccountDbProcessor, AccountDeletionDbProcessor; wires into Atlas pipeline; supports COPY bulk; tested via docker-compose; closes https://github.com/Arch-Network/arch-rust-indexer/issues/6