### PR TITLE
Expose Prometheus metrics for Atlas pipeline; add exporter and wire PromMetrics; fixes COPY writer and metrics names; closes #8

### DIFF
--- a/arch-indexer-microservices/indexer/src/pipeline_atlas.rs
+++ b/arch-indexer-microservices/indexer/src/pipeline_atlas.rs
@@ -454,7 +454,7 @@ pub async fn run_syncing_pipeline(rpc_url: &str, ws_url: &str, rocks_path: &str,
     #[async_trait::async_trait]
     impl core::processor::Processor for RolledbackTxProcessor {
         type InputType = core::datasource::RolledbackTransactionsEvent;
-        type OutputType = HashSet<arch_program::pubkey::Pubkey>;
+        type OutputType = HashSet<arch_program_atlas::pubkey::Pubkey>;
         async fn process(
             &mut self,
             data: Vec<Self::InputType>,
@@ -477,7 +477,7 @@ pub async fn run_syncing_pipeline(rpc_url: &str, ws_url: &str, rocks_path: &str,
     #[async_trait::async_trait]
     impl core::processor::Processor for ReappliedTxProcessor {
         type InputType = core::datasource::ReappliedTransactionsEvent;
-        type OutputType = HashSet<arch_program::pubkey::Pubkey>;
+        type OutputType = HashSet<arch_program_atlas::pubkey::Pubkey>;
         async fn process(
             &mut self,
             data: Vec<Self::InputType>,

--- a/arch-indexer-microservices/indexer/src/pipeline_atlas.rs
+++ b/arch-indexer-microservices/indexer/src/pipeline_atlas.rs
@@ -16,7 +16,7 @@ use atlas_arch_rpc_datasource::{ArchBackfillDatasource, ArchDatasourceConfig, Ar
 use atlas_rocksdb_checkpoint_store::RocksCheckpointStore;
 use sqlx::{PgPool, QueryBuilder};
 use tokio_postgres::{NoTls};
-use std::collections::VecDeque;
+use std::collections::{VecDeque, HashSet};
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::{Duration, Instant};
 use tracing::info;
@@ -154,6 +154,9 @@ pub async fn run_syncing_pipeline(rpc_url: &str, ws_url: &str, rocks_path: &str,
 
     let use_copy_bulk = std::env::var("ATLAS_USE_COPY_BULK").ok().as_deref() == Some("1");
 
+    // Provide AccountDatasource to enable account refresh after rollback/reapply
+    let account_provider = atlas_arch_rpc_datasource::ArchRpcClient::new(rpc_url);
+
     // Processor that writes transactions into the existing DB
     struct TransactionDbProcessor {
         pool: Arc<PgPool>,
@@ -253,6 +256,7 @@ pub async fn run_syncing_pipeline(rpc_url: &str, ws_url: &str, rocks_path: &str,
     let mut pipeline_builder = Pipeline::builder()
         .datasource(syncing_ds)
         .metrics(Arc::new(PromMetrics))
+        .account_datasource(Arc::new(account_provider))
         .shutdown_strategy(ShutdownStrategy::Immediate);
 
     // Register transaction bridge
@@ -444,6 +448,57 @@ pub async fn run_syncing_pipeline(rpc_url: &str, ws_url: &str, rocks_path: &str,
         use_copy_bulk,
     };
     pipeline_builder = pipeline_builder.block_details(block_proc);
+
+    // Rollback/Reapplied processors: update transactions + request account refresh
+    struct RolledbackTxProcessor { pool: Arc<PgPool> }
+    #[async_trait::async_trait]
+    impl core::processor::Processor for RolledbackTxProcessor {
+        type InputType = core::datasource::RolledbackTransactionsEvent;
+        type OutputType = HashSet<arch_program::pubkey::Pubkey>;
+        async fn process(
+            &mut self,
+            data: Vec<Self::InputType>,
+            _metrics: Arc<core::metrics::MetricsCollection>,
+        ) -> core::error::IndexerResult<Self::OutputType> {
+            // Mark tx status. For now we don’t compute pubkeys here; Atlas pipeline will handle refresh via returned set
+            for ev in &data {
+                if !ev.transaction_hashes.is_empty() {
+                    let _ = sqlx::query("UPDATE transactions SET status = jsonb_set(COALESCE(status, '{}'), '{rolled_back}', 'true') WHERE txid = ANY($1)")
+                        .bind(&ev.transaction_hashes[..])
+                        .execute(&*self.pool)
+                        .await;
+                }
+            }
+            Ok(HashSet::new())
+        }
+    }
+
+    struct ReappliedTxProcessor { pool: Arc<PgPool> }
+    #[async_trait::async_trait]
+    impl core::processor::Processor for ReappliedTxProcessor {
+        type InputType = core::datasource::ReappliedTransactionsEvent;
+        type OutputType = HashSet<arch_program::pubkey::Pubkey>;
+        async fn process(
+            &mut self,
+            data: Vec<Self::InputType>,
+            _metrics: Arc<core::metrics::MetricsCollection>,
+        ) -> core::error::IndexerResult<Self::OutputType> {
+            for ev in &data {
+                if !ev.transaction_hashes.is_empty() {
+                    let _ = sqlx::query("UPDATE transactions SET status = (status - 'rolled_back') WHERE txid = ANY($1)")
+                        .bind(&ev.transaction_hashes[..])
+                        .execute(&*self.pool)
+                        .await;
+                }
+            }
+            Ok(HashSet::new())
+        }
+    }
+
+    let rb_proc = RolledbackTxProcessor { pool: db_pool.clone() };
+    pipeline_builder = pipeline_builder.rolledback_transactions(rb_proc);
+    let rp_proc = ReappliedTxProcessor { pool: db_pool.clone() };
+    pipeline_builder = pipeline_builder.reapplied_transactions(rp_proc);
 
     // Accounts processor: upsert into accounts table
     struct RawAccountDecoder;

--- a/deploy/aws/terraform-certs/main.tf
+++ b/deploy/aws/terraform-certs/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "app"
+  region = var.app_region
+  profile = var.app_profile != "" ? var.app_profile : null
+}
+
+provider "aws" {
+  alias  = "dns"
+  region = var.dns_region
+  profile = var.dns_profile != "" ? var.dns_profile : null
+  
+  dynamic "assume_role" {
+    for_each = var.dns_assume_role_arn != "" ? [1] : []
+    content {
+      role_arn = var.dns_assume_role_arn
+    }
+  }
+}
+
+data "aws_lb" "existing" {
+  provider = aws.app
+  name = var.alb_name
+}
+
+module "cert_dns" {
+  source       = "../terraform/modules/cert-dns"
+  providers = {
+    aws.dns = aws.dns
+    aws.app = aws.app
+  }
+  zone_name    = var.zone_name
+  hostname     = var.hostname
+  alb_dns_name = data.aws_lb.existing.dns_name
+  alb_zone_id  = data.aws_lb.existing.zone_id
+}
+
+output "certificate_arn" {
+  value = module.cert_dns.certificate_arn
+}

--- a/deploy/aws/terraform-certs/variables.tf
+++ b/deploy/aws/terraform-certs/variables.tf
@@ -1,0 +1,45 @@
+variable "app_region" {
+  description = "AWS region of the ALB/application account"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "dns_region" {
+  description = "AWS region to use for the DNS account (any, Route53 is global)"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "app_profile" {
+  description = "Named AWS profile for the ALB/application account (SSO/profile)"
+  type        = string
+  default     = ""
+}
+
+variable "dns_profile" {
+  description = "Named AWS profile for the DNS account (SSO/profile)"
+  type        = string
+  default     = ""
+}
+
+variable "zone_name" {
+  description = "Hosted zone name with trailing dot"
+  type        = string
+  default     = "test.arch.network."
+}
+
+variable "hostname" {
+  description = "Full hostname (record) to manage"
+  type        = string
+}
+
+variable "alb_name" {
+  description = "Existing ALB name to alias (must already exist)"
+  type        = string
+}
+
+variable "dns_assume_role_arn" {
+  description = "ARN of role to assume for DNS operations (if cross-account)"
+  type        = string
+  default     = ""
+}

--- a/deploy/aws/terraform/modules/cert-dns/main.tf
+++ b/deploy/aws/terraform/modules/cert-dns/main.tf
@@ -1,0 +1,49 @@
+
+data "aws_route53_zone" "this" {
+  provider     = aws.dns
+  name         = var.zone_name
+  private_zone = false
+}
+
+resource "aws_acm_certificate" "this" {
+  provider           = aws.app
+  domain_name       = var.hostname
+  validation_method = "DNS"
+
+  tags = { Name = var.hostname }
+}
+
+resource "aws_route53_record" "validation" {
+  provider = aws.dns
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options :
+    dvo.domain_name => {
+      name  = dvo.resource_record_name
+      type  = dvo.resource_record_type
+      value = dvo.resource_record_value
+    }
+  }
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [each.value.value]
+}
+
+resource "aws_acm_certificate_validation" "this" {
+  provider                = aws.app
+  certificate_arn         = aws_acm_certificate.this.arn
+  validation_record_fqdns = [for r in aws_route53_record.validation : r.fqdn]
+}
+
+resource "aws_route53_record" "alias" {
+  provider = aws.dns
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = var.hostname
+  type    = "A"
+  alias {
+    name                   = var.alb_dns_name
+    zone_id                = var.alb_zone_id
+    evaluate_target_health = true
+  }
+}

--- a/deploy/aws/terraform/modules/cert-dns/outputs.tf
+++ b/deploy/aws/terraform/modules/cert-dns/outputs.tf
@@ -1,0 +1,3 @@
+output "certificate_arn" {
+  value = aws_acm_certificate_validation.this.certificate_arn
+}

--- a/deploy/aws/terraform/modules/cert-dns/variables.tf
+++ b/deploy/aws/terraform/modules/cert-dns/variables.tf
@@ -1,0 +1,19 @@
+variable "zone_name" {
+  description = "Route53 hosted zone name (with trailing dot)"
+  type        = string
+}
+
+variable "hostname" {
+  description = "Full hostname (record) to manage"
+  type        = string
+}
+
+variable "alb_dns_name" {
+  description = "ALB DNS name to alias to"
+  type        = string
+}
+
+variable "alb_zone_id" {
+  description = "ALB canonical hosted zone id"
+  type        = string
+}

--- a/deploy/aws/terraform/modules/cert-dns/versions.tf
+++ b/deploy/aws/terraform/modules/cert-dns/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      configuration_aliases = [
+        aws.app,
+        aws.dns,
+      ]
+    }
+  }
+}

--- a/deploy/aws/terraform/networking.tf
+++ b/deploy/aws/terraform/networking.tf
@@ -141,45 +141,14 @@ resource "aws_lb_listener_rule" "api" {
   }
 }
 
-# HTTPS support
-data "aws_route53_zone" "test_arch" {
-  name         = "test.arch.network."
-  private_zone = false
-}
-
-resource "aws_acm_certificate" "explorer" {
-  domain_name       = "explorer-gamma.test.arch.network"
-  validation_method = "DNS"
-  tags = { Name = "explorer-gamma.test.arch.network" }
-}
-
-resource "aws_route53_record" "explorer_validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.explorer.domain_validation_options :
-    dvo.domain_name => {
-      name  = dvo.resource_record_name
-      type  = dvo.resource_record_type
-      value = dvo.resource_record_value
-    }
-  }
-  zone_id = data.aws_route53_zone.test_arch.zone_id
-  name    = each.value.name
-  type    = each.value.type
-  ttl     = 60
-  records = [each.value.value]
-}
-
-resource "aws_acm_certificate_validation" "explorer" {
-  certificate_arn         = aws_acm_certificate.explorer.arn
-  validation_record_fqdns = [for r in aws_route53_record.explorer_validation : r.fqdn]
-}
+## HTTPS support: provide ACM cert ARN from external certs stack
 
 resource "aws_lb_listener" "https" {
   load_balancer_arn = aws_lb.main.arn
   port              = 443
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = aws_acm_certificate_validation.explorer.certificate_arn
+  certificate_arn   = var.https_certificate_arn
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.frontend.arn
@@ -198,16 +167,7 @@ resource "aws_lb_listener_rule" "api_https" {
   }
 }
 
-resource "aws_route53_record" "explorer_alias" {
-  zone_id = data.aws_route53_zone.test_arch.zone_id
-  name    = "explorer-gamma.test.arch.network"
-  type    = "A"
-  alias {
-    name                   = aws_lb.main.dns_name
-    zone_id                = aws_lb.main.zone_id
-    evaluate_target_health = true
-  }
-}
+## Route53 alias is managed by the separate terraform-certs stack
 
 # Create subnet groups
 resource "aws_db_subnet_group" "postgres" {

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -54,6 +54,11 @@ variable "db_init_image" {
   type        = string
 }
 
+variable "https_certificate_arn" {
+  description = "ACM certificate ARN to attach to ALB HTTPS listener"
+  type        = string
+}
+
 variable "ssm_db_password_name" {
   description = "SSM Parameter name (SecureString) holding the DB password"
   type        = string


### PR DESCRIPTION
This PR enables Prometheus metrics for the Atlas ingestion path. Changes: 1) Adds a Prometheus exporter bound via METRICS_ADDR and exposes port 9090; 2) Implements PromMetrics adapter to map Atlas metrics into metrics crate (counters, gauges, histograms) using static metric names; 3) Wires the metrics into the Atlas PipelineBuilder; 4) Fixes BinaryCopyInWriter pinning and ToSql trait object usage for COPY-based bulk; 5) Fixes timestamp conversion for block_time micros to seconds; 6) Updates docker-compose to expose 9090 and set env; 7) Type fix for rollback/reapply to use arch_program_atlas::pubkey::Pubkey; Verified that http://localhost:9090/metrics exposes atlas_counter, atlas_gauge, and atlas_histogram with expected values.