### PR TITLE
Migrate to public atlas-arch crates

### DIFF
--- a/arch-indexer-microservices/indexer/Cargo.lock
+++ b/arch-indexer-microservices/indexer/Cargo.lock
@@ -136,36 +136,6 @@ dependencies = [
 
 [[package]]
 name = "arch_program"
-version = "0.5.6"
-source = "git+https://github.com/Arch-Network/atlas?branch=master#c48c6c006b1425de502275c2cd4d523fb84b7b33"
-dependencies = [
- "anyhow",
- "bincode",
- "bitcode",
- "bitcoin",
- "bitcoin-io",
- "bitcoin_slices",
- "borsh",
- "bs58 0.5.1",
- "bytemuck",
- "hex",
- "libsecp256k1",
- "memoffset",
- "num-derive",
- "num-traits",
- "rand 0.8.5",
- "rustversion",
- "serde",
- "serde_bytes",
- "serde_derive",
- "sha256",
- "sha3",
- "solana-sanitize",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "arch_program"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2260ffb62964996663287e7f1a527b23ed47ef57464eda3c22ff8d8b6703e22b"
@@ -195,11 +165,12 @@ dependencies = [
 
 [[package]]
 name = "arch_sdk"
-version = "0.5.6"
-source = "git+https://github.com/Arch-Network/atlas?branch=master#c48c6c006b1425de502275c2cd4d523fb84b7b33"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b7ba7358a861fc80c06923631a0da99d8b20bce49002ed49e1b5279a1dd140"
 dependencies = [
  "anyhow",
- "arch_program 0.5.6",
+ "arch_program",
  "base64 0.22.1",
  "bip322",
  "bitcode",
@@ -217,19 +188,12 @@ dependencies = [
  "serde_json",
  "sha256",
  "snafu",
- "termsize",
  "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tracing",
  "uuid",
 ]
-
-[[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -249,29 +213,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "atlas-arch-rpc-datasource"
-version = "0.1.0"
-source = "git+https://github.com/Arch-Network/atlas?branch=master#c48c6c006b1425de502275c2cd4d523fb84b7b33"
+name = "atlas-arch"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b07dcaf005cec62fe0ab9bbf6220ebadf328d1717cc9d9d305f78c97ac5a28"
 dependencies = [
- "arch_program 0.5.6",
- "arch_sdk",
- "async-trait",
- "atlas-core",
- "futures",
- "hex",
- "thiserror 1.0.69",
- "titan-client",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "atlas-core"
-version = "0.1.0"
-source = "git+https://github.com/Arch-Network/atlas?branch=master#c48c6c006b1425de502275c2cd4d523fb84b7b33"
-dependencies = [
- "arch_program 0.5.6",
+ "arch_program",
  "arch_sdk",
  "async-trait",
  "borsh",
@@ -286,16 +233,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "atlas-rocksdb-checkpoint-store"
-version = "0.1.0"
-source = "git+https://github.com/Arch-Network/atlas?branch=master#c48c6c006b1425de502275c2cd4d523fb84b7b33"
+name = "atlas-arch-rpc-datasource"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db75b0e908f9b010c1044ed71e69c555b26c4382dc6c989ec625b8a52e3673b"
 dependencies = [
+ "arch_program",
+ "arch_sdk",
  "async-trait",
- "atlas-core",
- "log",
- "rocksdb",
+ "atlas-arch",
+ "futures",
+ "hex",
  "thiserror 1.0.69",
+ "titan-client",
  "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -439,24 +392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.9.2",
- "cexpr",
- "clang-sys",
- "itertools",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -715,33 +650,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -769,17 +683,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -940,12 +843,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,15 +946,6 @@ dependencies = [
  "quote",
  "syn 2.0.106",
  "unicode-xid",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -1361,12 +1249,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2d1aab06663bdce00d6ca5e5ed586ec8d18033a771906c993a1e3755b368d85"
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,7 +1383,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1598,7 +1480,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1856,13 +1738,11 @@ name = "indexer"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "arch_program 0.5.6",
- "arch_program 0.5.8",
+ "arch_program",
  "arch_sdk",
  "async-trait",
+ "atlas-arch",
  "atlas-arch-rpc-datasource",
- "atlas-core",
- "atlas-rocksdb-checkpoint-store",
  "axum",
  "bs58 0.3.1",
  "bytes",
@@ -1964,29 +1844,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.3",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -2035,16 +1896,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
-name = "libloading"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
-dependencies = [
- "cfg-if",
- "windows-targets 0.53.3",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,81 +1913,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "librocksdb-sys"
-version = "0.17.3+10.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
-dependencies = [
- "bindgen",
- "bzip2-sys",
- "cc",
- "libc",
- "libz-sys",
- "lz4-sys",
- "zstd-sys",
-]
-
-[[package]]
-name = "libsecp256k1"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
-dependencies = [
- "arrayref",
- "base64 0.22.1",
- "digest 0.9.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.8.5",
- "serde",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2184,16 +1964,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "lz4-sys"
-version = "1.11.1+lz4-1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2224,7 +1994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3130,23 +2900,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rocksdb"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec73b20525cb235bad420f911473b69f9fe27cc856c5461bccd7e4af037f43"
-dependencies = [
- "libc",
- "librocksdb-sys",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
  "const-oid",
- "digest 0.10.7",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -3470,7 +3230,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3487,7 +3247,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3509,7 +3269,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
 
@@ -3543,7 +3303,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -3765,7 +3525,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest",
  "dotenvy",
  "either",
  "futures-channel",
@@ -3988,16 +3748,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "termsize"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f11ff5c25c172608d5b85e2fb43ee9a6d683a7f4ab7f96ae07b3d8b590368fd"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -5252,14 +5002,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/arch-indexer-microservices/indexer/Cargo.toml
+++ b/arch-indexer-microservices/indexer/Cargo.toml
@@ -37,12 +37,10 @@ clap = { version = "4.5.45", features = ["derive"] }
 
 async-trait = { version = "0.1", optional = true }
 tokio-util = { version = "0.7", optional = true }
-atlas-core = { git = "https://github.com/Arch-Network/atlas", package = "atlas-core", branch = "master", optional = true }
-atlas-arch-rpc-datasource = { git = "https://github.com/Arch-Network/atlas", package = "atlas-arch-rpc-datasource", branch = "master", optional = true }
-atlas-rocksdb-checkpoint-store = { git = "https://github.com/Arch-Network/atlas", package = "atlas-rocksdb-checkpoint-store", branch = "master", optional = true }
+atlas-arch = { version = "0.1.1", optional = true }
+atlas-arch-rpc-datasource = { version = "0.1.1", optional = true }
 arch_program = { version = "0.5.8", optional = true }
-arch_program_atlas = { git = "https://github.com/Arch-Network/atlas", package = "arch_program", branch = "master", optional = true }
-arch_sdk = { git = "https://github.com/Arch-Network/atlas", package = "arch_sdk", branch = "master", optional = true }
+arch_sdk = { version = "0.5.8", optional = true }
 
 [lib]
 name = "indexer"
@@ -58,10 +56,9 @@ default = []
 atlas_ingestion = [
     "dep:async-trait",
     "dep:tokio-util",
-    "dep:atlas-core",
+    "dep:atlas-arch",
     "dep:atlas-arch-rpc-datasource",
-    "dep:atlas-rocksdb-checkpoint-store",
-    "dep:arch_program_atlas",
+    "dep:arch_program",
     "dep:arch_sdk",
 ]
 


### PR DESCRIPTION
Replace forked Git deps with crates.io: atlas-core -> atlas-arch 0.1.1; atlas-arch-rpc-datasource 0.1.1; switch arch_program/arch_sdk to crates.io 0.5.8; remove atlas-rocksdb-checkpoint-store and implement a simple file-based CheckpointStore compatible with atlas-arch; update feature flags and import paths; verified cargo build with --features atlas_ingestion passes.